### PR TITLE
Fixed to use original size

### DIFF
--- a/packages/scene-graph-mediator/runtime/src/property_converter/Pixi.ts
+++ b/packages/scene-graph-mediator/runtime/src/property_converter/Pixi.ts
@@ -62,8 +62,17 @@ export const Pixi: PropertyConverter.Interface = {
     }
 
     if (target.anchor) {
-      convertedObject.position.x += target.width  * convertedObject.scale.x * transform.anchor.x;
-      convertedObject.position.y += target.height * convertedObject.scale.y * transform.anchor.y;
+      const size = {
+        width: target.width,
+        height: target.height
+      };
+      // should calcurate with original size
+      if (target.texture) {
+        size.width  = target.texture.width;
+        size.height = target.texture.height;
+      }
+      convertedObject.position.x += size.width  * convertedObject.scale.x * transform.anchor.x;
+      convertedObject.position.y += size.height * convertedObject.scale.y * transform.anchor.y;
     }
   },
 


### PR DESCRIPTION
Calculated size of entity was used in previous version.
It caused wrong coordinate conversion.

This PR fixes this issue by using entity's original size retrieved from `texture` property.
