### PR TITLE
[mediator/unity/client] Fix relative path

### DIFF
--- a/packages/scene-graph-unity/client/src/exporter/asset/DefaultAssetExporter.ts
+++ b/packages/scene-graph-unity/client/src/exporter/asset/DefaultAssetExporter.ts
@@ -135,7 +135,7 @@ export default class DefaultAssetExporter implements sgmed.AssetExporter {
     urlNameSpace: string,
     movePath: string = ''
   ): sgmed.AssetExportMapEntity {
-    const destRelativePath = (movePath || basePath).replace(RegExp(`\^${assetRoot}`), '');
+    const destRelativePath = path.relative(assetRoot, (movePath || basePath));
     return {
       localSrcPath: basePath,
       localDestPath: path.join(destDir, destRelativePath),


### PR DESCRIPTION
# Summary
+ Fix relative path problem of Unity [Cocos ver comment](https://github.com/drecom/scene-graph/pull/40#commitcomment-33815890)

## Changed
+ src/exporter/asset/DefaultAssetExporter.ts

## Files to review
+ src/exporter/asset/DefaultAssetExporter.ts

## Test
- [x] ~~example/UnityProject/Assets/Scenes/SampleScene.unity~~
  -> the scene does not contain skinned mesh renderer.

#### Output (Windows/Mac)
``` js
const destRelativePath = path.relative(assetRoot, (movePath || basePath));
const olddestRelativePath = (movePath || basePath).replace(RegExp(`\^${assetRoot}`), '');
console.log(destRelativePath);
console.log(olddestRelativePath);
```
``` 
// Win
destRelativePath : Resources\untitled.fbx
olddestRelativePath: C:\Users\user_name\Drecom\Repository\scene-graph\packages\scene-graph-unity\client\example\UnityProject\Assets\Resources\untitled.fbx
```
``` 
// Mac
destRelativePath : Resources\untitled.fbx
olddestRelativePath: Users\user_name\Drecom\Repository\scene-graph\packages\scene-graph-unity\client\example\UnityProject\Assets\Resources\untitled.fbx
```

## New Issue
[mediator/client/unity] EmbededMaterial parse will fail
https://github.com/drecom/scene-graph/issues/60